### PR TITLE
Convert Rust server to sync database interface while preserving write serialization

### DIFF
--- a/rust/src/lib/service.rs
+++ b/rust/src/lib/service.rs
@@ -21,7 +21,7 @@ impl KvStore for KvStoreGrpcService {
     async fn get(&self, request: Request<GetRequest>) -> Result<Response<GetResponse>, Status> {
         let req = request.into_inner();
         
-        match self.db.get(&req.key).await {
+        match self.db.get(&req.key) {
             Ok(result) => Ok(Response::new(GetResponse {
                 value: result.value,
                 found: result.found,
@@ -33,7 +33,7 @@ impl KvStore for KvStoreGrpcService {
     async fn put(&self, request: Request<PutRequest>) -> Result<Response<PutResponse>, Status> {
         let req = request.into_inner();
         
-        let result = self.db.put(&req.key, &req.value).await;
+        let result = self.db.put(&req.key, &req.value);
         Ok(Response::new(PutResponse {
             success: result.success,
             error: result.error,
@@ -43,7 +43,7 @@ impl KvStore for KvStoreGrpcService {
     async fn delete(&self, request: Request<DeleteRequest>) -> Result<Response<DeleteResponse>, Status> {
         let req = request.into_inner();
         
-        let result = self.db.delete(&req.key).await;
+        let result = self.db.delete(&req.key);
         Ok(Response::new(DeleteResponse {
             success: result.success,
             error: result.error,
@@ -54,7 +54,7 @@ impl KvStore for KvStoreGrpcService {
         let req = request.into_inner();
         
         let limit = if req.limit >= 0 { req.limit as u32 } else { 0 };
-        match self.db.list_keys(&req.prefix, limit).await {
+        match self.db.list_keys(&req.prefix, limit) {
             Ok(keys) => Ok(Response::new(ListKeysResponse { keys })),
             Err(e) => Err(Status::internal(e)),
         }


### PR DESCRIPTION
## Summary
Convert the Rust KV server from async database interface to pure sync while preserving the critical requirement of single-thread write serialization.

## Key Changes
- **Database Interface**: Convert all `async fn` methods to sync `fn`
- **Write Serialization**: Maintain single-thread write processing using `std::sync::mpsc` instead of `tokio::sync::mpsc`
- **Thrift Server**: Remove Tokio runtime dependency, use direct sync database calls
- **gRPC Service**: Update to use sync database methods
- **Concurrency**: Preserve thread-per-connection model for network I/O

## Concurrency Model
- **Reads**: Multiple connection threads can read concurrently
- **Writes**: All writes serialized through single worker thread ✅ (preserved requirement)
- **Network**: Thread-per-connection handles multiple clients in parallel

## Benefits
- **Simpler Code**: Eliminates async/await complexity for inherently blocking operations
- **Better Performance**: Removes async-over-sync overhead
- **Same Guarantees**: Maintains all concurrency and consistency requirements
- **Zero Breaking Changes**: All existing Thrift/gRPC clients work unchanged

## Testing
- ✅ Rust server builds successfully
- ✅ Thrift server starts without errors  
- ✅ gRPC server builds successfully
- ✅ Single-thread write serialization preserved
- ✅ Client compatibility maintained

## Files Changed
- `rust/src/lib/db.rs`: Convert database interface from async to sync
- `rust/src/lib/service.rs`: Update gRPC service to use sync methods
- `rust/src/servers/thrift_server.rs`: Remove Tokio runtime, use direct sync calls

🤖 Generated with [Claude Code](https://claude.ai/code)