### PR TITLE
Fix test suite port configuration for reliable testing

### DIFF
--- a/rust/tests/client/abort_test.rs
+++ b/rust/tests/client/abort_test.rs
@@ -1,8 +1,10 @@
 use rocksdb_server::client::KvStoreClient;
 
+use crate::common;
+
 #[tokio::test]
 async fn test_transaction_abort() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // First, let's check if the key exists before we start
     let pre_tx_future = client.begin_transaction(None, Some(30));

--- a/rust/tests/client/binary_key_test.rs
+++ b/rust/tests/client/binary_key_test.rs
@@ -1,8 +1,10 @@
 use rocksdb_server::client::KvStoreClient;
 
+use crate::common;
+
 #[tokio::test]
 async fn test_read_transaction_binary_keys_snapshot_get() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // First, set up binary data with a regular transaction
     let tx_future = client.begin_transaction(None, Some(30));
@@ -36,7 +38,7 @@ async fn test_read_transaction_binary_keys_snapshot_get() -> Result<(), Box<dyn 
 
 #[tokio::test]
 async fn test_read_transaction_binary_keys_get() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // First, set up binary data with a regular transaction
     let tx_future = client.begin_transaction(None, Some(30));

--- a/rust/tests/client/integration_test.rs
+++ b/rust/tests/client/integration_test.rs
@@ -2,9 +2,11 @@ use rocksdb_server::client::{KvStoreClient, KvError};
 use std::time::Duration;
 use tokio::time::timeout;
 
+use crate::common;
+
 #[tokio::test]
 async fn test_basic_operations() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // Begin transaction
     let tx_future = client.begin_transaction(None, Some(30));
@@ -28,7 +30,7 @@ async fn test_basic_operations() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn test_transaction_conflict() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // Start two transactions
     let tx1_future = client.begin_transaction(None, Some(30));
@@ -85,7 +87,7 @@ async fn test_transaction_conflict() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn test_range_operations() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // Begin transaction
     let tx_future = client.begin_transaction(None, Some(30));
@@ -130,7 +132,7 @@ async fn test_range_operations() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn test_read_transaction() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // First, set up some data with a regular transaction
     let setup_tx_future = client.begin_transaction(None, Some(30));
@@ -169,7 +171,7 @@ async fn test_read_transaction() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn test_read_transaction_binary_keys() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // First, set up binary data with a regular transaction
     let tx_future = client.begin_transaction(None, Some(30));
@@ -217,7 +219,7 @@ async fn test_read_transaction_binary_keys() -> Result<(), Box<dyn std::error::E
 
 #[tokio::test]
 async fn test_versionstamped_operations() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // Begin transaction
     let tx_future = client.begin_transaction(None, Some(30));
@@ -250,7 +252,7 @@ async fn test_connection_timeout() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn test_transaction_timeout() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // Begin transaction with very short timeout
     let tx_future = client.begin_transaction(None, Some(1));
@@ -288,7 +290,7 @@ async fn test_transaction_timeout() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn test_ping() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     let ping_future = client.ping(Some("test message".as_bytes().to_vec()));
     let response = ping_future.await_result().await?;
@@ -300,7 +302,7 @@ async fn test_ping() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn test_delete_operation() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
 
     // Begin transaction
     let tx_future = client.begin_transaction(None, Some(30));
@@ -332,7 +334,7 @@ async fn test_delete_operation() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn test_binary_data_range_operations() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
 
     // Begin transaction
     let tx_future = client.begin_transaction(None, Some(30));
@@ -542,7 +544,7 @@ async fn test_binary_data_range_operations() -> Result<(), Box<dyn std::error::E
 
 #[tokio::test]
 async fn test_u64_range_operations() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
 
     // Begin transaction
     let tx_future = client.begin_transaction(None, Some(30));

--- a/rust/tests/client/versionstamped_test.rs
+++ b/rust/tests/client/versionstamped_test.rs
@@ -1,8 +1,10 @@
 use rocksdb_server::client::KvStoreClient;
 
+use crate::common;
+
 #[tokio::test]
 async fn test_versionstamped_key_operations() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // Begin transaction
     let tx_future = client.begin_transaction(None, Some(30));
@@ -37,7 +39,7 @@ async fn test_versionstamped_key_operations() -> Result<(), Box<dyn std::error::
 
 #[tokio::test]
 async fn test_versionstamped_value_operations() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // Begin transaction
     let tx_future = client.begin_transaction(None, Some(30));
@@ -72,7 +74,7 @@ async fn test_versionstamped_value_operations() -> Result<(), Box<dyn std::error
 
 #[tokio::test]
 async fn test_mixed_versionstamped_operations() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // Begin transaction
     let tx_future = client.begin_transaction(None, Some(30));
@@ -122,7 +124,7 @@ async fn test_mixed_versionstamped_operations() -> Result<(), Box<dyn std::error
 
 #[tokio::test]
 async fn test_versionstamp_uniqueness() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // First transaction
     let tx1_future = client.begin_transaction(None, Some(30));
@@ -152,7 +154,7 @@ async fn test_versionstamp_uniqueness() -> Result<(), Box<dyn std::error::Error>
 
 #[tokio::test] 
 async fn test_backward_compatibility_commit() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // Begin transaction
     let tx_future = client.begin_transaction(None, Some(30));
@@ -172,7 +174,7 @@ async fn test_backward_compatibility_commit() -> Result<(), Box<dyn std::error::
 
 #[tokio::test]
 async fn test_versionstamp_buffer_size_validation() -> Result<(), Box<dyn std::error::Error>> {
-    let client = KvStoreClient::connect("localhost:9090")?;
+    let client = KvStoreClient::connect(&common::get_server_address())?;
     
     // Test 1: Key buffer too small (< 10 bytes)
     let tx_future = client.begin_transaction(None, Some(30));

--- a/rust/tests/client_integration_tests.rs
+++ b/rust/tests/client_integration_tests.rs
@@ -10,11 +10,12 @@ use rocksdb_server::client::KvStoreClient;
 #[tokio::test]
 async fn test_client_connectivity() -> Result<(), Box<dyn std::error::Error>> {
     // This test serves as an entry point to verify client connectivity
+    let server_addr = common::get_server_address();
     println!("Testing client connectivity...");
-    println!("Make sure the Thrift server is running on localhost:9090");
-    
+    println!("Make sure the Thrift server is running on {}", server_addr);
+
     // Simple connectivity test (KvStoreClient::connect is synchronous, not async)
-    match KvStoreClient::connect("localhost:9090") {
+    match KvStoreClient::connect(&server_addr) {
         Ok(_) => {
             println!("✅ Successfully connected to Thrift server");
             Ok(())

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -142,13 +142,30 @@ fn find_available_port() -> Result<u16, Box<dyn std::error::Error + Send + Sync>
 pub async fn wait_for_server_ready(port: u16, timeout_secs: u64) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let timeout = Duration::from_secs(timeout_secs);
     let start = std::time::Instant::now();
-    
+
     while start.elapsed() < timeout {
         if TcpStream::connect(format!("127.0.0.1:{}", port)).is_ok() {
             return Ok(());
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
-    
+
     Err("Server did not become ready within timeout".into())
+}
+
+/// Get server address from environment or default to localhost:9090
+#[allow(dead_code)]
+pub fn get_server_address() -> String {
+    // Check for full server address first
+    if let Ok(addr) = std::env::var("KV_TEST_SERVER_ADDRESS") {
+        return addr;
+    }
+
+    // Check for port only and build address
+    if let Ok(port) = std::env::var("KV_TEST_SERVER_PORT") {
+        return format!("localhost:{}", port);
+    }
+
+    // Default fallback
+    "localhost:9090".to_string()
 }

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -143,8 +143,8 @@ test_rust_workspace() {
 
     log_info "Running cargo test --workspace in rust/ directory"
 
-    # Change to rust directory and run tests
-    if (cd ../rust && cargo test --workspace); then
+    # Change to rust directory and run tests with correct server port
+    if (cd ../rust && KV_TEST_SERVER_PORT="$THRIFT_SERVER_PORT" cargo test --workspace); then
         log_success "Rust workspace tests completed successfully"
         return 0
     else


### PR DESCRIPTION
## Summary
- Add configurable server address helper in common test module
- Update all client tests to use environment-configurable server port  
- Modify test runner to pass correct server port to Rust workspace tests
- Replace hardcoded localhost:9090 with dynamic address resolution
- Support KV_TEST_SERVER_PORT and KV_TEST_SERVER_ADDRESS env vars

## Changes
This commit ensures tests connect to the correct server instance during automated test runs, fixing connectivity failures when test server runs on non-default ports.

## Test plan
- [x] Tests use environment-configurable server addresses
- [x] Test runner passes correct server port to Rust workspace tests
- [x] All client tests support dynamic address resolution
- [x] Environment variables KV_TEST_SERVER_PORT and KV_TEST_SERVER_ADDRESS work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)