### PR TITLE
Phase 1.2: Add serde serialization methods to existing operations

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,6 +19,7 @@ ordered-float = "4.2"
 tokio-util = { version = "0.7", features = ["compat"] }
 toml = "0.8"
 serde = { version = "1.0", features = ["derive"] }
+bincode = "1.3"
 clap = { version = "4.0", features = ["derive"] }
 uuid = { version = "1.0", features = ["v4"] }
 tempfile = "3.8"
@@ -67,6 +68,7 @@ ordered-float = { workspace = true }
 tokio-util = { workspace = true }
 toml = { workspace = true }
 serde = { workspace = true }
+bincode = { workspace = true }
 clap = { workspace = true }
 uuid = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
## Summary

This PR implements Phase 1.2 of the Paxos replication plan by adding serde serialization/deserialization methods to existing operation types in the KV store.

### Changes Made

- **Add bincode dependency**: Added to both workspace and package dependencies for binary serialization
- **Serde derives**: Added `serde::Serialize` and `serde::Deserialize` to:
  - `WriteOperation` enum (also added `Clone`)
  - `AtomicOperation` struct 
  - `AtomicCommitRequest` struct (also added `Clone`)
- **Serialization methods**: Implemented `serialize()` and `deserialize()` methods for all three types using bincode
- **Comprehensive testing**: Added `test_operation_serialization` to verify round-trip serialization works correctly

### Technical Details

This implementation follows the Phase 1.2 requirements by updating existing operation types rather than creating new consensus-specific ones. This approach:

- Maintains consistency with the current codebase
- Enables these operations to be transmitted through the RSML consensus layer
- Provides a foundation for the upcoming consensus replication features
- Adds minimal overhead and doesn't break existing functionality

### Testing

- All existing tests pass
- New serialization test verifies round-trip functionality for all operation types
- Code compiles successfully with the new dependencies

This prepares the codebase for Phase 1.3+ where these serializable operations will be used with the RSML consensus library.

🤖 Generated with [Claude Code](https://claude.ai/code)