### PR TITLE
docs: Update Phase 1 implementation status documentation

### DIFF
--- a/docs/paxos-implementation-plan.md
+++ b/docs/paxos-implementation-plan.md
@@ -295,8 +295,18 @@ async fn main() -> Result<(), KvError> {
 
 ## Phase 1: Happy Path - Basic Working Replication (Week 2)
 
+**Status**: 🔄 **In Progress** - Foundation work completed, consensus layer implementation pending
+- ✅ Operation serialization implemented (using existing types in `rust/src/lib/db.rs`)
+- ✅ Dependencies added (bincode, serde)
+- ❌ RSML integration pending
+- ❌ Consensus components pending (executor, replica manager, router)
+
+**See**: [Phase 1 Detailed Implementation Plan](impl/phase1-implementation-plan.md) for current status
+
 ### 1.1 Simple Operation Type for Consensus
 **Goal**: Get one operation type working through Paxos.
+
+**✅ COMPLETED**: Instead of creating new types, enhanced existing `WriteOperation`, `AtomicOperation`, and `AtomicCommitRequest` with serialization support.
 
 **Start with single operation**:
 ```rust


### PR DESCRIPTION
## Summary
Update Phase 1 implementation documentation to reflect current progress and completed foundation work.

## Changes Made
- **Phase 1 Implementation Plan** (`docs/impl/phase1-implementation-plan.md`):
  - ✅ Mark operation serialization as completed (using existing `WriteOperation`, `AtomicOperation`, `AtomicCommitRequest` types)
  - ✅ Update dependencies status (bincode, serde already added)
  - 🔄 Add progress indicators for in-progress and pending tasks
  - 📅 Update timeline with current status (Day 1: 50% complete, Day 6: in progress)
  - 🔧 Specify new `thrift-replicated-server` executable approach vs modifying existing server

- **Main Paxos Plan** (`docs/paxos-implementation-plan.md`):
  - ✅ Add Phase 1 status overview with progress indicators
  - 📖 Reference detailed implementation plan for current status
  - ✅ Mark operation type work as completed using enhanced existing types

## Current Implementation Status
**Foundation Work Completed** (from recent commits):
- ✅ Operation serialization with serde derives and bincode methods
- ✅ Dependencies properly added to workspace
- ✅ Replica-aware database creation support

**Remaining Work**:
- ❌ RSML library integration
- ❌ Consensus components (KvStoreExecutor, ReplicaManager, ConsensusRouter)
- ❌ New replicated server executable implementation

## Test Plan
- [x] Documentation builds and renders correctly
- [x] Status indicators accurately reflect implementation state
- [x] References between documents are correct

🤖 Generated with [Claude Code](https://claude.ai/code)