### PR TITLE
Create consensus crate foundation with generic interfaces (#41)

### DIFF
--- a/docs/multi-node-architecture.md
+++ b/docs/multi-node-architecture.md
@@ -484,11 +484,11 @@ impl MultiNodeClient {
    - ✅ `OperationResult` types defined for network serialization
    - ✅ Separate database paths for different replica instances
 
-3. ⚠️ **Refactor Thrift Adapter** (PARTIAL)
+3. ✅ **Refactor Thrift Adapter** ✅ **COMPLETED**
    - ✅ Clean `ThriftKvAdapter` structure exists in `rust/src/lib/thrift_adapter.rs`
    - ✅ Separation of concerns between protocol handling and business logic
-   - ❌ No routing logic implemented - still calls database directly
-   - ❌ No operation dispatcher for distributed routing
+   - ✅ Routing logic fully implemented - all operations go through `RoutingManager`
+   - ✅ Operation dispatcher for distributed routing implemented
 
 4. ✅ **Add Configuration Structure** (`rust/src/lib/config.rs`)
    - ✅ Complete deployment mode configuration with `DeploymentMode::Replicated`
@@ -496,23 +496,23 @@ impl MultiNodeClient {
    - ✅ Backward compatibility maintained for existing single-node config
    - ✅ Integration with database factory pattern
 
-### Phase 1: Basic Routing Infrastructure ❌ **NOT STARTED**
+### Phase 1: Basic Routing Infrastructure ✅ **COMPLETED**
 
 **Goal**: Add routing layer without consensus - operations still execute locally.
 
-5. ❌ **Implement Routing Manager**
-   - ❌ No `RoutingManager` implementation found
-   - ❌ No read/write classification at routing level
-   - ❌ No placeholder for consensus integration
+5. ✅ **Implement Routing Manager** ✅ **COMPLETED**
+   - ✅ Complete `RoutingManager` implementation in `rust/src/lib/replication/routing_manager.rs`
+   - ✅ Full read/write classification at routing level using `DatabaseOperation` trait
+   - ✅ Placeholder for consensus integration prepared for Phase 2
 
-6. ❌ **Create Enhanced Thrift Adapter**
-   - ❌ No routing manager integration in Thrift adapter
-   - ❌ Direct database calls still used throughout
-   - ❌ No distributed error handling patterns
+6. ✅ **Create Enhanced Thrift Adapter** ✅ **COMPLETED**
+   - ✅ Full routing manager integration in Thrift adapter (`rust/src/lib/thrift_adapter.rs`)
+   - ✅ No direct database calls - all operations routed through `RoutingManager`
+   - ✅ Distributed error handling patterns implemented
 
-7. ❌ **Add Local Testing**
-   - ❌ No routing-specific tests implemented
-   - ❌ No regression testing for distributed mode
+7. ✅ **Add Local Testing** ✅ **COMPLETED**
+   - ✅ Comprehensive routing-specific tests implemented (`routing_manager.rs:402-538`)
+   - ✅ Regression testing for both standalone and replicated modes
 
 ### Phase 2: Multi-Node Foundation ❌ **NOT STARTED**
 
@@ -595,31 +595,26 @@ impl MultiNodeClient {
 - **Solid foundation** for distributed system implementation
 
 ### What's Missing ❌
-- **Routing Manager**: No request routing between read and write operations
 - **Consensus Integration**: No Raft/Paxos implementation or RSML integration
 - **Multi-node Client**: Client only connects to single node
 - **Distributed Testing**: No multi-node test infrastructure
 - **State Machine**: No consensus-based operation application
 
 ### Next Priority Tasks
-1. **Implement Routing Manager** (`rust/src/replication/routing_manager.rs`)
-   - Route read operations to local database
-   - Route write operations through consensus (placeholder initially)
-   - Handle consistency levels and error conditions
+1. **Choose and Integrate Consensus Library**
+   - Add Raft library dependency (e.g., `raft-rs` or `openraft`)
+   - Implement consensus manager abstraction
+   - Create state machine executor
 
-2. **Create Enhanced Thrift Adapter**
-   - Replace direct database calls with routing manager
-   - Add distributed error handling (NotLeader, timeout, etc.)
-
-3. **Add Basic Multi-node Infrastructure**
+2. **Add Basic Multi-node Infrastructure**
    - Multi-node server executable
    - Node discovery and health checking
    - Basic client-side load balancing
 
-4. **Choose and Integrate Consensus Library**
-   - Add Raft library dependency (e.g., `raft-rs` or `openraft`)
-   - Implement consensus manager abstraction
-   - Create state machine executor
+3. **Implement Multi-node Client**
+   - Client with leader discovery and failover
+   - Read load balancing across replicas
+   - Connection pooling and retry logic
 
 The codebase has excellent foundations for distributed implementation, with the hardest design decisions already made and core abstractions in place. The remaining work is primarily about connecting these pieces with consensus and networking logic.
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,7 +4,9 @@ members = [
     "crates/benchmark",
     "crates/kv-storage-api",
     "crates/kv-storage-rocksdb",
-    "crates/kv-storage-mockdb"
+    "crates/kv-storage-mockdb",
+    "crates/consensus-api",
+    "crates/consensus-mock"
 ]
 resolver = "2"
 

--- a/rust/crates/consensus-api/Cargo.toml
+++ b/rust/crates/consensus-api/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "consensus-api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+uuid = { workspace = true, features = ["serde"] }

--- a/rust/crates/consensus-api/src/config.rs
+++ b/rust/crates/consensus-api/src/config.rs
@@ -1,0 +1,89 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::Duration;
+
+use crate::NodeId;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConsensusConfig {
+    pub node_id: NodeId,
+    pub cluster_members: HashMap<NodeId, String>,
+    pub timeouts: TimeoutConfig,
+    pub algorithm: AlgorithmConfig,
+    pub storage: StorageConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimeoutConfig {
+    pub election_timeout_min: Duration,
+    pub election_timeout_max: Duration,
+    pub heartbeat_interval: Duration,
+    pub append_entries_timeout: Duration,
+    pub request_timeout: Duration,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AlgorithmConfig {
+    pub algorithm_type: AlgorithmType,
+    pub batch_size: usize,
+    pub max_log_entries_per_request: usize,
+    pub snapshot_threshold: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AlgorithmType {
+    Raft,
+    Pbft,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageConfig {
+    pub log_dir: String,
+    pub snapshot_dir: String,
+    pub sync_writes: bool,
+}
+
+impl Default for ConsensusConfig {
+    fn default() -> Self {
+        Self {
+            node_id: "node-1".to_string(),
+            cluster_members: HashMap::new(),
+            timeouts: TimeoutConfig::default(),
+            algorithm: AlgorithmConfig::default(),
+            storage: StorageConfig::default(),
+        }
+    }
+}
+
+impl Default for TimeoutConfig {
+    fn default() -> Self {
+        Self {
+            election_timeout_min: Duration::from_millis(150),
+            election_timeout_max: Duration::from_millis(300),
+            heartbeat_interval: Duration::from_millis(50),
+            append_entries_timeout: Duration::from_millis(100),
+            request_timeout: Duration::from_secs(5),
+        }
+    }
+}
+
+impl Default for AlgorithmConfig {
+    fn default() -> Self {
+        Self {
+            algorithm_type: AlgorithmType::Raft,
+            batch_size: 100,
+            max_log_entries_per_request: 1000,
+            snapshot_threshold: 10000,
+        }
+    }
+}
+
+impl Default for StorageConfig {
+    fn default() -> Self {
+        Self {
+            log_dir: "./consensus_logs".to_string(),
+            snapshot_dir: "./consensus_snapshots".to_string(),
+            sync_writes: false,
+        }
+    }
+}

--- a/rust/crates/consensus-api/src/error.rs
+++ b/rust/crates/consensus-api/src/error.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+pub type ConsensusResult<T> = Result<T, ConsensusError>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ConsensusError {
+    SerializationError {
+        message: String,
+    },
+    Other {
+        message: String,
+    },
+}
+
+impl fmt::Display for ConsensusError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConsensusError::SerializationError { message } => {
+                write!(f, "Serialization error: {}", message)
+            }
+            ConsensusError::Other { message } => {
+                write!(f, "Other error: {}", message)
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConsensusError {}

--- a/rust/crates/consensus-api/src/lib.rs
+++ b/rust/crates/consensus-api/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod config;
+pub mod error;
+pub mod traits;
+
+pub use config::*;
+pub use error::*;
+pub use traits::*;

--- a/rust/crates/consensus-api/src/traits.rs
+++ b/rust/crates/consensus-api/src/traits.rs
@@ -1,0 +1,61 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use uuid::Uuid;
+
+use crate::ConsensusResult;
+
+pub type NodeId = String;
+pub type Term = u64;
+pub type Index = u64;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProposeResponse {
+    pub request_id: Uuid,
+    pub success: bool,
+    pub index: Option<Index>,
+    pub term: Option<Term>,
+    pub error: Option<String>,
+    pub leader_id: Option<NodeId>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LogEntry {
+    pub index: Index,
+    pub term: Term,
+    pub data: Vec<u8>,
+    pub timestamp: u64,
+}
+
+#[async_trait]
+pub trait ConsensusNode: Send + Sync + Debug {
+    async fn propose(&self, data: Vec<u8>) -> ConsensusResult<ProposeResponse>;
+
+    async fn start(&mut self) -> ConsensusResult<()>;
+
+    async fn stop(&mut self) -> ConsensusResult<()>;
+
+    fn is_leader(&self) -> bool;
+
+    fn current_term(&self) -> Term;
+
+    fn node_id(&self) -> &NodeId;
+
+    fn cluster_members(&self) -> Vec<NodeId>;
+
+    async fn add_node(&mut self, node_id: NodeId, address: String) -> ConsensusResult<()>;
+
+    async fn remove_node(&mut self, node_id: &NodeId) -> ConsensusResult<()>;
+
+    async fn wait_for_commit(&self, index: Index) -> ConsensusResult<Vec<u8>>;
+
+    async fn apply(&self, entry: &LogEntry) -> ConsensusResult<Vec<u8>>;
+
+    async fn snapshot(&self) -> ConsensusResult<Vec<u8>>;
+
+    async fn restore_snapshot(&self, snapshot: &[u8]) -> ConsensusResult<()>;
+
+    fn last_applied_index(&self) -> Index;
+
+    fn set_last_applied_index(&self, index: Index);
+}

--- a/rust/crates/consensus-mock/Cargo.toml
+++ b/rust/crates/consensus-mock/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "consensus-mock"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+consensus-api = { path = "../consensus-api" }
+tokio = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+uuid = { workspace = true, features = ["serde"] }
+bincode = { workspace = true }
+tracing = { workspace = true }
+parking_lot = { workspace = true }

--- a/rust/crates/consensus-mock/src/lib.rs
+++ b/rust/crates/consensus-mock/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod mock_node;
+
+pub use mock_node::{MockConsensusNode, StateMachine};

--- a/rust/crates/consensus-mock/src/mock_node.rs
+++ b/rust/crates/consensus-mock/src/mock_node.rs
@@ -1,0 +1,195 @@
+use async_trait::async_trait;
+use consensus_api::{
+    ConsensusNode, ConsensusResult, Index, LogEntry, NodeId, ProposeResponse, Term,
+};
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub struct MockConsensusNode {
+    node_id: NodeId,
+    term: AtomicU64,
+    log: Arc<RwLock<Vec<LogEntry>>>,
+    last_applied_index: AtomicU64,
+    is_leader: AtomicBool,
+    is_started: AtomicBool,
+    cluster_members: Arc<RwLock<HashMap<NodeId, String>>>,
+    state_machine: Box<dyn StateMachine>,
+}
+
+pub trait StateMachine: Send + Sync + std::fmt::Debug {
+    fn apply(&self, entry: &LogEntry) -> ConsensusResult<Vec<u8>>;
+    fn snapshot(&self) -> ConsensusResult<Vec<u8>>;
+    fn restore_snapshot(&self, snapshot: &[u8]) -> ConsensusResult<()>;
+}
+
+impl MockConsensusNode {
+    pub fn new(node_id: NodeId, state_machine: Box<dyn StateMachine>) -> Self {
+        let mut cluster_members = HashMap::new();
+        cluster_members.insert(node_id.clone(), "localhost:0".to_string());
+
+        Self {
+            node_id,
+            term: AtomicU64::new(1),
+            log: Arc::new(RwLock::new(Vec::new())),
+            last_applied_index: AtomicU64::new(0),
+            is_leader: AtomicBool::new(true),
+            is_started: AtomicBool::new(false),
+            cluster_members: Arc::new(RwLock::new(cluster_members)),
+            state_machine,
+        }
+    }
+
+    fn next_index(&self) -> Index {
+        let log = self.log.read();
+        log.len() as Index + 1
+    }
+
+    fn apply_pending_entries(&self) -> ConsensusResult<()> {
+        let log = self.log.read();
+        let current_applied = self.last_applied_index.load(Ordering::SeqCst);
+
+        for (i, entry) in log.iter().enumerate() {
+            let entry_index = (i + 1) as Index;
+            if entry_index > current_applied {
+                self.state_machine.apply(entry)?;
+                self.last_applied_index.store(entry_index, Ordering::SeqCst);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ConsensusNode for MockConsensusNode {
+    async fn propose(&self, data: Vec<u8>) -> ConsensusResult<ProposeResponse> {
+        if !self.is_started.load(Ordering::SeqCst) {
+            return Ok(ProposeResponse {
+                request_id: Uuid::new_v4(),
+                success: false,
+                index: None,
+                term: None,
+                error: Some("Node not started".to_string()),
+                leader_id: None,
+            });
+        }
+
+        if !self.is_leader() {
+            return Ok(ProposeResponse {
+                request_id: Uuid::new_v4(),
+                success: false,
+                index: None,
+                term: Some(self.current_term()),
+                error: Some("Not leader".to_string()),
+                leader_id: None,
+            });
+        }
+
+        let index = self.next_index();
+        let term = self.current_term();
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
+        let entry = LogEntry {
+            index,
+            term,
+            data,
+            timestamp,
+        };
+
+        {
+            let mut log = self.log.write();
+            log.push(entry);
+        }
+
+        self.apply_pending_entries()?;
+
+        Ok(ProposeResponse {
+            request_id: Uuid::new_v4(),
+            success: true,
+            index: Some(index),
+            term: Some(term),
+            error: None,
+            leader_id: Some(self.node_id.clone()),
+        })
+    }
+
+    async fn start(&mut self) -> ConsensusResult<()> {
+        self.is_started.store(true, Ordering::SeqCst);
+        tracing::info!("Mock consensus node '{}' started", self.node_id);
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> ConsensusResult<()> {
+        self.is_started.store(false, Ordering::SeqCst);
+        tracing::info!("Mock consensus node '{}' stopped", self.node_id);
+        Ok(())
+    }
+
+    fn is_leader(&self) -> bool {
+        self.is_leader.load(Ordering::SeqCst)
+    }
+
+    fn current_term(&self) -> Term {
+        self.term.load(Ordering::SeqCst)
+    }
+
+    fn node_id(&self) -> &NodeId {
+        &self.node_id
+    }
+
+    fn cluster_members(&self) -> Vec<NodeId> {
+        self.cluster_members.read().keys().cloned().collect()
+    }
+
+    async fn add_node(&mut self, node_id: NodeId, address: String) -> ConsensusResult<()> {
+        let mut members = self.cluster_members.write();
+        members.insert(node_id.clone(), address);
+        tracing::info!("Added node '{}' to cluster", node_id);
+        Ok(())
+    }
+
+    async fn remove_node(&mut self, node_id: &NodeId) -> ConsensusResult<()> {
+        let mut members = self.cluster_members.write();
+        members.remove(node_id);
+        tracing::info!("Removed node '{}' from cluster", node_id);
+        Ok(())
+    }
+
+    async fn wait_for_commit(&self, index: Index) -> ConsensusResult<Vec<u8>> {
+        let log = self.log.read();
+        if let Some(entry) = log.get((index - 1) as usize) {
+            Ok(entry.data.clone())
+        } else {
+            Err(consensus_api::ConsensusError::Other {
+                message: format!("Log entry at index {} not found", index),
+            })
+        }
+    }
+
+    async fn apply(&self, entry: &LogEntry) -> ConsensusResult<Vec<u8>> {
+        self.state_machine.apply(entry)
+    }
+
+    async fn snapshot(&self) -> ConsensusResult<Vec<u8>> {
+        self.state_machine.snapshot()
+    }
+
+    async fn restore_snapshot(&self, snapshot: &[u8]) -> ConsensusResult<()> {
+        self.state_machine.restore_snapshot(snapshot)
+    }
+
+    fn last_applied_index(&self) -> Index {
+        self.last_applied_index.load(Ordering::SeqCst)
+    }
+
+    fn set_last_applied_index(&self, index: Index) {
+        self.last_applied_index.store(index, Ordering::SeqCst);
+    }
+}

--- a/rust/crates/consensus-mock/tests/counter_test.rs
+++ b/rust/crates/consensus-mock/tests/counter_test.rs
@@ -1,0 +1,176 @@
+use consensus_api::{ConsensusNode, ConsensusResult, LogEntry};
+use consensus_mock::{MockConsensusNode, StateMachine};
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CounterCommand {
+    Increment,
+    Decrement,
+    Set(u64),
+    Get,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum CounterResponse {
+    Value(u64),
+    Ack,
+}
+
+#[derive(Debug)]
+pub struct CounterStateMachine {
+    value: Arc<AtomicU64>,
+    last_applied_index: AtomicU64,
+}
+
+impl CounterStateMachine {
+    pub fn new() -> Self {
+        Self {
+            value: Arc::new(AtomicU64::new(0)),
+            last_applied_index: AtomicU64::new(0),
+        }
+    }
+
+    pub fn get_value(&self) -> u64 {
+        self.value.load(Ordering::SeqCst)
+    }
+
+    fn deserialize_command(&self, data: &[u8]) -> ConsensusResult<CounterCommand> {
+        bincode::deserialize(data).map_err(|e| consensus_api::ConsensusError::SerializationError {
+            message: format!("Failed to deserialize command: {}", e),
+        })
+    }
+
+    fn serialize_response(&self, response: &CounterResponse) -> ConsensusResult<Vec<u8>> {
+        bincode::serialize(response).map_err(|e| consensus_api::ConsensusError::SerializationError {
+            message: format!("Failed to serialize response: {}", e),
+        })
+    }
+
+    fn apply_command(&self, command: CounterCommand) -> ConsensusResult<CounterResponse> {
+        let response = match command {
+            CounterCommand::Increment => {
+                self.value.fetch_add(1, Ordering::SeqCst);
+                CounterResponse::Ack
+            }
+            CounterCommand::Decrement => {
+                self.value.fetch_sub(1, Ordering::SeqCst);
+                CounterResponse::Ack
+            }
+            CounterCommand::Set(value) => {
+                self.value.store(value, Ordering::SeqCst);
+                CounterResponse::Ack
+            }
+            CounterCommand::Get => {
+                let value = self.value.load(Ordering::SeqCst);
+                CounterResponse::Value(value)
+            }
+        };
+
+        Ok(response)
+    }
+}
+
+impl StateMachine for CounterStateMachine {
+    fn apply(&self, entry: &LogEntry) -> ConsensusResult<Vec<u8>> {
+        let command = self.deserialize_command(&entry.data)?;
+        let response = self.apply_command(command)?;
+        self.serialize_response(&response)
+    }
+
+    fn snapshot(&self) -> ConsensusResult<Vec<u8>> {
+        let value = self.value.load(Ordering::SeqCst);
+        let last_applied = self.last_applied_index.load(Ordering::SeqCst);
+
+        let snapshot_data = (value, last_applied);
+        bincode::serialize(&snapshot_data)
+            .map_err(|e| consensus_api::ConsensusError::SerializationError {
+                message: format!("Failed to serialize snapshot: {}", e),
+            })
+    }
+
+    fn restore_snapshot(&self, snapshot: &[u8]) -> ConsensusResult<()> {
+        let (value, last_applied): (u64, u64) = bincode::deserialize(snapshot)
+            .map_err(|e| consensus_api::ConsensusError::SerializationError {
+                message: format!("Failed to deserialize snapshot: {}", e),
+            })?;
+
+        self.value.store(value, Ordering::SeqCst);
+        self.last_applied_index.store(last_applied, Ordering::SeqCst);
+
+        Ok(())
+    }
+}
+
+fn create_command_data(command: CounterCommand) -> Vec<u8> {
+    bincode::serialize(&command).unwrap()
+}
+
+fn deserialize_response(data: &[u8]) -> CounterResponse {
+    bincode::deserialize(data).unwrap()
+}
+
+#[tokio::test]
+async fn test_mock_consensus_with_counter() {
+    let counter_sm = CounterStateMachine::new();
+    let mut node = MockConsensusNode::new("node-1".to_string(), Box::new(counter_sm));
+
+    node.start().await.unwrap();
+    assert!(node.is_leader());
+    assert_eq!(node.node_id(), "node-1");
+
+    let command_data = create_command_data(CounterCommand::Increment);
+    let response = node.propose(command_data).await.unwrap();
+    assert!(response.success);
+    assert_eq!(response.index, Some(1));
+
+    let command_data = create_command_data(CounterCommand::Increment);
+    let response = node.propose(command_data).await.unwrap();
+    assert!(response.success);
+    assert_eq!(response.index, Some(2));
+
+    let command_data = create_command_data(CounterCommand::Get);
+    let response = node.propose(command_data).await.unwrap();
+    assert!(response.success);
+    assert_eq!(response.index, Some(3));
+
+    let commit_data = node.wait_for_commit(3).await.unwrap();
+    let response_data = node.apply(&LogEntry {
+        index: 3,
+        term: 1,
+        data: commit_data,
+        timestamp: 0,
+    }).await.unwrap();
+    let counter_response = deserialize_response(&response_data);
+    assert_eq!(counter_response, CounterResponse::Value(2));
+
+    node.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mock_consensus_not_started() {
+    let counter_sm = CounterStateMachine::new();
+    let node = MockConsensusNode::new("node-1".to_string(), Box::new(counter_sm));
+
+    let command_data = create_command_data(CounterCommand::Increment);
+    let response = node.propose(command_data).await.unwrap();
+    assert!(!response.success);
+    assert!(response.error.unwrap().contains("not started"));
+}
+
+#[tokio::test]
+async fn test_mock_consensus_cluster_management() {
+    let counter_sm = CounterStateMachine::new();
+    let mut node = MockConsensusNode::new("node-1".to_string(), Box::new(counter_sm));
+
+    assert_eq!(node.cluster_members(), vec!["node-1".to_string()]);
+
+    node.add_node("node-2".to_string(), "localhost:8001".to_string()).await.unwrap();
+    let members = node.cluster_members();
+    assert!(members.contains(&"node-1".to_string()));
+    assert!(members.contains(&"node-2".to_string()));
+
+    node.remove_node(&"node-2".to_string()).await.unwrap();
+    assert_eq!(node.cluster_members(), vec!["node-1".to_string()]);
+}


### PR DESCRIPTION
## Summary
- Created consensus-api crate with pure traits and types for consensus algorithms
- Created consensus-mock crate with simple in-memory implementation for testing
- Implemented generic ConsensusNode trait supporting any state machine via byte buffers
- Added mock implementation with straightforward propose/commit without real consensus protocol
- Added counter state machine tests that validate the interface works correctly

## Implementation Details

### consensus-api Crate
- `ConsensusNode` trait - Core consensus interface with propose/start/stop operations
- `ProposeResponse`, `LogEntry` - Data types for consensus operations
- `ConsensusError`, `ConsensusResult` - Error handling
- `ConsensusConfig` - Configuration types for different algorithms

### consensus-mock Crate  
- `MockConsensusNode` - Simple in-memory consensus simulation
- `StateMachine` trait - For pluggable state machines
- No real consensus protocol - immediately "commits" proposed entries
- Always acts as leader when started
- Perfect for testing and development

### Key Design Decisions
- Buffer-based interface using `Vec<u8>` instead of generics for real-world compatibility
- Unified trait combining consensus operations and state machine application
- Follows existing pattern of `kv-storage-api` + `kv-storage-mockdb`
- Ready for future `consensus-raft`, `consensus-pbft` implementations

## Test Plan
- [x] consensus-api crate compiles successfully
- [x] consensus-mock crate compiles successfully  
- [x] Counter state machine tests pass (3 test cases)
- [x] Mock consensus node properly handles start/stop lifecycle
- [x] Mock consensus node supports cluster membership changes
- [x] Workspace builds successfully with new crates

## Future Extensions
This foundation enables implementing real consensus algorithms:
- `consensus-raft` - Full Raft implementation
- `consensus-pbft` - Byzantine fault tolerance
- All using the same `consensus-api` interface

Closes #41

🤖 Generated with [Claude Code](https://claude.ai/code)