### PR TITLE
Refactor CI workflows to use unified CMake build process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,37 +70,14 @@ jobs:
         restore-keys: |
           googletest-${{ runner.os }}-
 
-    - name: Generate protocol files
+    - name: Build everything with CMake
       run: |
         cmake -B build -S .
-        cmake --build build --target generate_thrift
-
-    - name: Build Rust dependencies first
-      run: |
-        cd rust
-        # Force download and build all dependencies
-        cargo fetch
-        # Exclude RSML features since private submodule is not available in CI
-        cargo check --workspace --no-default-features --features ffi
-      env:
-        CARGO_INCREMENTAL: 1
-
-    - name: Build Rust components
-      run: |
-        cd rust
-        # Build without RSML features
-        cargo build --bin server --bin thrift-server --no-default-features --features ffi
-      env:
-        CARGO_INCREMENTAL: 1
-
-    - name: Build FFI library and tests
-      run: |
-        cmake --build build --target rust_client_lib cpp_ffi_test
+        cmake --build build
 
     - name: Start Thrift server for tests
       run: |
-        cd rust
-        cargo run --bin thrift-server &
+        ./build/bin/rocksdbserver-thrift &
         # Wait for server to start
         for i in {1..30}; do
           if nc -z localhost 9090 2>/dev/null; then
@@ -112,8 +89,7 @@ jobs:
 
     - name: Run FFI tests
       run: |
-        cd build/bin
-        ./cpp_ffi_test
+        ./build/bin/cpp_ffi_test
 
     - name: Run Rust tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y protobuf-compiler thrift-compiler librocksdb-dev
+        sudo apt-get install -y protobuf-compiler thrift-compiler librocksdb-dev cmake build-essential
 
     - name: Set up Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -61,19 +61,10 @@ jobs:
         restore-keys: |
           cmake-build-${{ runner.os }}-
 
-    - name: Generate protocol files
+    - name: Build everything with CMake
       run: |
         cmake -B build -S .
-        cmake --build build --target generate_thrift
-
-    - name: Build Rust dependencies first
-      run: |
-        cd rust
-        cargo fetch
-        # Exclude RSML features since private submodule is not available in CI
-        cargo check --workspace --no-default-features --features ffi
-      env:
-        CARGO_INCREMENTAL: 1
+        cmake --build build
 
     - name: Run Rust tests (excluding client integration tests)
       run: |
@@ -105,7 +96,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y protobuf-compiler thrift-compiler librocksdb-dev
+        sudo apt-get install -y protobuf-compiler thrift-compiler librocksdb-dev cmake build-essential
 
     - name: Set up Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -138,31 +129,14 @@ jobs:
         restore-keys: |
           cmake-build-${{ runner.os }}-
 
-    - name: Generate protocol files
+    - name: Build everything with CMake
       run: |
         cmake -B build -S .
-        cmake --build build --target generate_thrift
-
-    - name: Build Rust dependencies first
-      run: |
-        cd rust
-        cargo fetch
-        # Exclude RSML features since private submodule is not available in CI
-        cargo check --workspace --no-default-features --features ffi
-      env:
-        CARGO_INCREMENTAL: 1
-
-    - name: Build Thrift server (debug)
-      run: |
-        cd rust
-        # Build without RSML features
-        cargo build --bin thrift-server --no-default-features --features ffi
-      env:
-        CARGO_INCREMENTAL: 1
+        cmake --build build
 
     - name: Run benchmark crate tests
       env:
-        THRIFT_SERVER_BIN: ./rust/target/debug/thrift-server
+        THRIFT_SERVER_BIN: ./build/bin/rocksdbserver-thrift
       run: |
         cd rust
         cargo test -p kv-benchmark --verbose -- --nocapture
@@ -191,10 +165,10 @@ jobs:
         restore-keys: |
           cmake-build-nodejs-${{ runner.os }}-
 
-    - name: Generate protocol files
+    - name: Build everything with CMake
       run: |
         cmake -B build -S .
-        cmake --build build --target generate_thrift
+        cmake --build build
 
     - name: Copy generated files to expected location
       run: |


### PR DESCRIPTION
## Summary
This PR refactors the GitHub Actions CI workflows to use a unified CMake build process, simplifying the build pipeline and ensuring consistency with local development workflow.

### Key Changes
- **Unified Build Process**: Replace multiple separate cargo and cmake build steps with single `cmake --build build` command
- **Consistent Binary Paths**: Update all server binary references from `./rust/target/debug/thrift-server` to `./build/bin/rocksdbserver-thrift`
- **Enhanced Dependencies**: Add `cmake` and `build-essential` to system dependencies for proper CMake support
- **Simplified Configuration**: Remove redundant build steps and cargo-specific commands

### Files Modified
- `.github/workflows/ci.yml`: Streamlined build and test execution
- `.github/workflows/test.yml`: Updated all test jobs to use CMake-built binaries

### Benefits
- **Reduced Complexity**: Fewer build steps and less cargo-specific configuration
- **Better Consistency**: CI now matches local development workflow (`cmake --build build`)
- **Improved Maintainability**: Single source of truth for build process
- **Faster Builds**: Eliminates duplicate compilation steps

### Test Plan
- [x] CI workflows updated to use CMake build
- [x] Server binary paths updated to build folder
- [x] All test jobs configured to use CMake-built binaries
- [ ] Verify CI passes with new configuration
- [ ] Confirm all tests run successfully with new binary paths

🤖 Generated with [Claude Code](https://claude.ai/code)