### PR TITLE
Clean up RSML consensus configuration and exports

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -27,10 +27,6 @@ pub use lib::operations::{KvOperation, OperationResult, OperationType, DatabaseO
 pub use lib::replication::{RoutingManager, RoutingError, RoutingResult};
 pub use lib::kv_state_machine::{KvStateMachine, ConsensusKvDatabase};
 
-// Conditionally re-export RSML consensus types when the feature is enabled
-// RSML exports removed - requires manual consensus-rsml dependency setup
-// #[cfg(feature = "rsml")]
-// pub use consensus_rsml::{RsmlFactoryBuilder, RsmlError, RsmlConfig};
 
 // Re-export generated Thrift types with prefix to avoid conflicts
 pub use generated::kvstore::{


### PR DESCRIPTION
## Summary
- Remove commented RSML exports from lib.rs for cleaner code
- Re-enable optional consensus-rsml dependency with proper feature syntax
- Update RSML feature documentation for better clarity

## Changes
- `rust/src/lib.rs`: Removed commented RSML export block
- `rust/Cargo.toml`: Re-enabled optional consensus-rsml dependency with `dep:` syntax
- Updated feature documentation to clarify RSML usage requirements

## Test plan
- [ ] Verify cargo build succeeds without rsml feature
- [ ] Verify cargo build --features rsml works when RSML submodule available
- [ ] Confirm no regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)