### PR TITLE
fix: Remove duplicate initializeApp function in Node.js app

### DIFF
--- a/nodejs/public/app.js
+++ b/nodejs/public/app.js
@@ -75,31 +75,6 @@ function processRawData(rawKeyValues) {
     });
 }
 
-// Initialize the page after components are loaded
-function initializeApp() {
-    testConnection();
-    loadKeys();
-    initializeSettings();
-
-    // Setup confirmation input listener
-    const confirmationInput = document.getElementById('clearAllConfirmation');
-    if (confirmationInput) {
-        confirmationInput.addEventListener('input', function() {
-            const executeButton = document.getElementById('clearAllExecute');
-            const statusText = document.getElementById('clearAllStatus');
-
-            if (this.value === 'DELETE ALL DATA') {
-                executeButton.disabled = false;
-                statusText.textContent = 'Ready to execute';
-                statusText.style.color = '#e53e3e';
-            } else {
-                executeButton.disabled = true;
-                statusText.textContent = this.value ? 'Incorrect confirmation phrase' : '';
-                statusText.style.color = '#666';
-            }
-        });
-    }
-}
 
 // Connection management
 async function testConnection() {
@@ -497,6 +472,28 @@ function initializeTabFromURL() {
 function initializeApp() {
     setupTabNavigation();
     initializeTabFromURL();
+    testConnection();
+    loadKeys();
+    initializeSettings();
+
+    // Setup confirmation input listener
+    const confirmationInput = document.getElementById('clearAllConfirmation');
+    if (confirmationInput) {
+        confirmationInput.addEventListener('input', function() {
+            const executeButton = document.getElementById('clearAllExecute');
+            const statusText = document.getElementById('clearAllStatus');
+
+            if (this.value === 'DELETE ALL DATA') {
+                executeButton.disabled = false;
+                statusText.textContent = 'Ready to execute';
+                statusText.style.color = '#e53e3e';
+            } else {
+                executeButton.disabled = true;
+                statusText.textContent = this.value ? 'Incorrect confirmation phrase' : '';
+                statusText.style.color = '#666';
+            }
+        });
+    }
 }
 
 // This initialization will be called by component-loader.js after components are loaded


### PR DESCRIPTION
## Summary
- Remove duplicate `initializeApp()` function definition in `nodejs/public/app.js`
- Consolidate initialization logic into a single function that includes tab navigation setup
- Improve code organization and eliminate potential conflicts

## Changes
- Removed the first duplicate `initializeApp()` function (lines 78-102)
- Kept the complete implementation that includes `setupTabNavigation()` and `initializeTabFromURL()`
- Maintained all existing functionality including connection testing, key loading, and settings initialization

## Test Plan
- [x] Verify the Node.js web interface loads correctly
- [x] Confirm tab navigation works properly
- [x] Test that all initialization functions are called correctly
- [x] Ensure no JavaScript errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)