### PR TITLE
Improve logging setup and ANSI compatibility

### DIFF
--- a/rust/crates/consensus-mock/Cargo.toml
+++ b/rust/crates/consensus-mock/Cargo.toml
@@ -18,6 +18,7 @@ parking_lot = { workspace = true }
 thrift = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
+tracing-subscriber = "0.3"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/rust/crates/consensus-mock/src/lib.rs
+++ b/rust/crates/consensus-mock/src/lib.rs
@@ -25,3 +25,11 @@ pub use consensus_server::ConsensusServer;
 pub use types::{
     AppendEntriesRequest, AppendEntriesResponse, LogEntry,
 };
+
+/// Initialize test logging with ANSI colors disabled
+/// Available for both unit tests and integration tests
+pub fn init_test_logging() {
+    let _ = tracing_subscriber::fmt()
+        .with_ansi(false)  // Disable ANSI color codes
+        .try_init();
+}

--- a/rust/crates/consensus-mock/tests/full_consensus_integration_tests.rs
+++ b/rust/crates/consensus-mock/tests/full_consensus_integration_tests.rs
@@ -324,7 +324,7 @@ impl Drop for FullConsensusCluster {
 /// Test basic consensus server setup and connectivity
 #[tokio::test]
 async fn test_full_consensus_cluster_setup() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     tracing::info!("=== Testing full consensus cluster setup ===");
 
@@ -344,7 +344,7 @@ async fn test_full_consensus_cluster_setup() {
 /// Test single operation execution across the cluster
 #[tokio::test]
 async fn test_single_operation_execution() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     tracing::info!("=== Testing single operation execution ===");
 
@@ -379,7 +379,7 @@ async fn test_single_operation_execution() {
 /// Test multiple operations execution
 #[tokio::test]
 async fn test_multiple_operations_execution() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     tracing::info!("=== Testing multiple operations execution ===");
 
@@ -418,7 +418,7 @@ async fn test_multiple_operations_execution() {
 /// Test state machine behavior with complex operations
 #[tokio::test]
 async fn test_state_machine_operations() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     tracing::info!("=== Testing state machine operations ===");
 
@@ -458,7 +458,7 @@ async fn test_state_machine_operations() {
 /// Test error handling and network issues
 #[tokio::test]
 async fn test_error_handling() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     tracing::info!("=== Testing error handling ===");
 
@@ -487,7 +487,7 @@ async fn test_error_handling() {
 /// Comprehensive end-to-end test
 #[tokio::test]
 async fn test_full_consensus_end_to_end() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     tracing::info!("=== Full End-to-End Consensus Test ===");
 

--- a/rust/crates/consensus-mock/tests/thrift_transport_integration_tests.rs
+++ b/rust/crates/consensus-mock/tests/thrift_transport_integration_tests.rs
@@ -66,7 +66,7 @@ impl ThriftConsensusCluster {
 /// Test that ThriftTransport can connect to endpoints
 #[tokio::test]
 async fn test_thrift_transport_connection_handling() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     let cluster = ThriftConsensusCluster::new(3, 19000).await.unwrap();
 
@@ -84,7 +84,7 @@ async fn test_thrift_transport_connection_handling() {
 /// Test that ThriftTransport properly handles endpoint management
 #[tokio::test]
 async fn test_thrift_transport_endpoint_management() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     let mut transport = ThriftTransport::new("test_node".to_string());
 
@@ -110,7 +110,7 @@ async fn test_thrift_transport_endpoint_management() {
 /// Test sending append entry requests through ThriftTransport
 #[tokio::test]
 async fn test_thrift_transport_append_entry_simulation() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     let cluster = ThriftConsensusCluster::new(2, 19010).await.unwrap();
     let leader_transport = cluster.get_transport(0).unwrap();
@@ -148,7 +148,7 @@ async fn test_thrift_transport_append_entry_simulation() {
 /// Test sending commit notifications through ThriftTransport
 #[tokio::test]
 async fn test_thrift_transport_commit_notification_simulation() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     let cluster = ThriftConsensusCluster::new(2, 19020).await.unwrap();
     let leader_transport = cluster.get_transport(0).unwrap();
@@ -175,7 +175,7 @@ async fn test_thrift_transport_commit_notification_simulation() {
 /// Test multi-node transport configuration
 #[tokio::test]
 async fn test_multi_node_thrift_transport_setup() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     let cluster = ThriftConsensusCluster::new(5, 19030).await.unwrap();
 
@@ -197,7 +197,7 @@ async fn test_multi_node_thrift_transport_setup() {
 /// Test error handling for invalid endpoints
 #[tokio::test]
 async fn test_thrift_transport_error_handling() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     let mut transport = ThriftTransport::new("test_node".to_string());
 
@@ -220,7 +220,7 @@ async fn test_thrift_transport_error_handling() {
 /// Test concurrent transport operations
 #[tokio::test]
 async fn test_concurrent_thrift_transport_operations() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     let cluster = ThriftConsensusCluster::new(3, 19040).await.unwrap();
     let transport = cluster.get_transport(0).unwrap().clone(); // Clone to avoid lifetime issues
@@ -250,7 +250,7 @@ async fn test_concurrent_thrift_transport_operations() {
 /// This test shows how the ThriftTransport would be used in a real consensus system
 #[tokio::test]
 async fn test_complete_consensus_flow_simulation() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_mock::init_test_logging();
 
     tracing::info!("=== Consensus Thrift Transport Integration Test ===");
 

--- a/rust/crates/consensus-rsml/Cargo.toml
+++ b/rust/crates/consensus-rsml/Cargo.toml
@@ -20,6 +20,7 @@ tracing = "0.1"
 serde_json = "1.0"
 dashmap = "6.0"
 chrono = { version = "0.4", features = ["serde"] }
+tracing-subscriber = "0.3"
 
 [features]
 default = []

--- a/rust/crates/consensus-rsml/src/lib.rs
+++ b/rust/crates/consensus-rsml/src/lib.rs
@@ -24,6 +24,14 @@ pub use engine::*;
 // Re-export key types from consensus-api for convenience
 pub use consensus_api::{ConsensusEngine, ConsensusConfig, StateMachine, ProposeResponse, LogEntry};
 
+/// Initialize test logging with ANSI colors disabled
+/// Available for both unit tests and integration tests
+pub fn init_test_logging() {
+    let _ = tracing_subscriber::fmt()
+        .with_ansi(false)  // Disable ANSI color codes
+        .try_init();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,7 +147,7 @@ mod tests {
     #[tokio::test]
     async fn test_consensus_factory_workflow() {
         // Initialize tracing for debugging
-        let _ = tracing_subscriber::fmt::try_init();
+        init_test_logging();
 
         println!("Hello World Consensus Test");
         println!("==========================");

--- a/rust/crates/consensus-rsml/tests/integration_tests.rs
+++ b/rust/crates/consensus-rsml/tests/integration_tests.rs
@@ -256,7 +256,7 @@ impl RsmlTestCluster {
 
 #[tokio::test]
 async fn test_rsml_single_node_basic_operations() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_rsml::init_test_logging();
 
     let mut config = RsmlConfig::default();
     config.base.node_id = "1".to_string();
@@ -292,7 +292,7 @@ async fn test_rsml_single_node_basic_operations() {
 
 #[tokio::test]
 async fn test_rsml_factory_pattern() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_rsml::init_test_logging();
 
     let mut factory = RsmlConsensusFactory::new();
 
@@ -323,7 +323,7 @@ async fn test_rsml_factory_pattern() {
 
 #[tokio::test]
 async fn test_rsml_multi_node_cluster_creation() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_rsml::init_test_logging();
 
     let result = RsmlTestCluster::new_inmemory(3).await;
 
@@ -353,7 +353,7 @@ async fn test_rsml_multi_node_cluster_creation() {
 
 #[tokio::test]
 async fn test_rsml_leader_follower_operations() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_rsml::init_test_logging();
 
     let result = RsmlTestCluster::new_inmemory(3).await;
 
@@ -403,7 +403,7 @@ async fn test_rsml_leader_follower_operations() {
 async fn test_rsml_tcp_transport() {
     use consensus_rsml::config::{TransportType, TcpConfig};
 
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_rsml::init_test_logging();
 
     let mut config = RsmlConfig::default();
     config.base.node_id = "1".to_string();
@@ -449,7 +449,7 @@ async fn test_rsml_tcp_transport() {
 
 #[tokio::test]
 async fn test_rsml_error_handling() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_rsml::init_test_logging();
 
     // Test invalid node ID
     let mut config = RsmlConfig::default();
@@ -482,7 +482,7 @@ async fn test_rsml_error_handling() {
 
 #[tokio::test]
 async fn test_rsml_consensus_operations() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_rsml::init_test_logging();
 
     let mut config = RsmlConfig::default();
     config.base.node_id = "1".to_string();
@@ -532,7 +532,7 @@ async fn test_rsml_consensus_operations() {
 
 #[tokio::test]
 async fn test_rsml_state_machine_integration() {
-    let _ = tracing_subscriber::fmt::try_init();
+    consensus_rsml::init_test_logging();
 
     let state_machine = Arc::new(TestStateMachine::new());
 

--- a/rust/src/client/config.rs
+++ b/rust/src/client/config.rs
@@ -75,6 +75,7 @@ pub fn init_debug_logging() {
         .with_thread_names(true)
         .with_file(true)
         .with_line_number(true)
+        .with_ansi(false)  // Disable ANSI color codes
         .try_init()
         .is_ok() {
         DEBUG_ENABLED.store(true, Ordering::Relaxed);

--- a/rust/src/client/ffi.rs
+++ b/rust/src/client/ffi.rs
@@ -116,7 +116,9 @@ pub struct KvCommitResult {
 #[no_mangle]
 pub extern "C" fn kv_init() -> c_int {
     // Initialize tracing for debugging
-    let _ = tracing_subscriber::fmt::try_init();
+    let _ = tracing_subscriber::fmt()
+        .with_ansi(false)  // Disable ANSI color codes
+        .try_init();
     0  // Return 0 for success (C convention)
 }
 

--- a/rust/src/servers/grpc_server.rs
+++ b/rust/src/servers/grpc_server.rs
@@ -9,7 +9,9 @@ use rocksdb_server::{Config, TransactionalKvDatabase};
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize tracing
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_ansi(false)  // Disable ANSI color codes
+        .init();
 
     // Load configuration from binary's directory
     let exe_path = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("."));

--- a/rust/src/servers/thrift_server.rs
+++ b/rust/src/servers/thrift_server.rs
@@ -94,6 +94,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with(
             fmt::layer()
                 .with_writer(non_blocking_file)
+                .with_ansi(false)
                 .with_target(true)
                 .with_thread_ids(true)
                 .with_file(true)


### PR DESCRIPTION
## Summary
- Add `init_test_logging` function to standardize test logging setup across all crates
- Disable ANSI colors in logging for better compatibility with non-ANSI terminals

## Changes
- **feat: Add init_test_logging function**: Standardizes test logging setup across crates with ANSI colors disabled
- **feat: Disable ANSI colors in logging**: Improves compatibility with non-ANSI terminals by disabling color codes in Thrift server logging

## Test Plan
- [x] Verify logging initialization works across all test suites
- [x] Confirm ANSI color codes are disabled in terminal output
- [x] Test compatibility with different terminal environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)